### PR TITLE
Replace lambda notification callback with nested function

### DIFF
--- a/main.py
+++ b/main.py
@@ -275,17 +275,20 @@ def show_notification(
             # ``win10toast_click`` provides clickable notifications on Windows.
             from win10toast_click import ToastNotifier
 
+            callback_fn = None
+            if callback and callback_arg is not None:
+
+                def callback_fn():
+                    callback(callback_arg)
+                    return 0
+
             toaster = ToastNotifier()
             toaster.show_toast(
                 title,
                 message,
                 duration=10,
                 threaded=True,
-                callback_on_click=(
-                    (lambda: callback(callback_arg))
-                    if callback and callback_arg is not None
-                    else None
-                ),
+                callback_on_click=callback_fn,
             )
         else:
             # Fallback for macOS/Linux using plyer.


### PR DESCRIPTION
## Summary
- Replace win10toast lambda callback with nested function that invokes the provided callback and returns 0.

## Testing
- `make lint`
- `make format-check`
- `make test` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68aec07ccb848323af4801808a28a3c6