### PR TITLE
Load file type mappings from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,23 @@ It also includes a **system tray** icon, allowing users to start and stop sortin
 ### 📁 Default Folder Structure
 AutoSort organizes files into the following default folders/categories, and checks for the following extensions (feel free to add any additional extensions you may need beyond these).
 
-- **Docs**: `.pdf`, `.docx`, `.xlsx`, `.pptx`, `.txt`, `.csv`, `.dotx`, `.doc`, `.ppt`, `.potx`
-- **Media**: `.jpg`, `.jpeg`, `.png`, `.gif`, `.mp4`, `.mov`, `.mp3`, `.wav`, `.webm`, `.svg`, `.webp`, `.ico`
+- **Docs**: `.pdf`, `.docx`, `.xlsx`, `.pptx`, `.txt`, `.csv`, `.dotx`, `.doc`, `.ppt`, `.potx`, `.text`
+- **Media**: `.jpg`, `.jpeg`, `.png`, `.gif`, `.mp4`, `.mov`, `.mp3`, `.wav`, `.webm`, `.svg`, `.webp`, `.ico`, `.m4a`
 - **Archives**: `.zip`, `.rar`, `.tar`, `.gz`, `.7z`
 - **Programs**: `.exe`, `.msi`, `.dmg`, `.pkg`, `.sh`, `.iso`
-- **Development**: `.py`, `.js`, `.html`, `.css`, `.cpp`, `.java`, `.sh`, `.ipynb`, `.json`, `.md`, `.m`, `.drawio`, `.ts`, `.log`
+- **Development**: `.py`, `.js`, `.html`, `.css`, `.cpp`, `.java`, `.sh`, `.ipynb`, `.json`, `.md`, `.m`, `.drawio`, `.ts`, `.log`, `.apk`, `.db`, `.sqlite`, `.sql`
+
+### ✏️ Custom File Types Configuration
+File type categories live in [`config/file_types.json`](config/file_types.json). The file contains a simple JSON object where each key is a category name and its value is a list of extensions:
+
+```json
+{
+  "Docs": [".pdf", ".txt"],
+  "Media": [".jpg", ".mp4"]
+}
+```
+
+Add new categories or extensions by editing this file. AutoSort reads the configuration at start-up and creates matching folders on your Desktop if needed. If the file is missing or invalid, the built-in default mappings shown above are used.
 
 #### 🎭 Meme Pop-Up Feature
 For personal use, AutoFileSort includes a **meme pop-up feature** that triggers when an image/media file is detected in the **Downloads** folder. 

--- a/config/file_types.json
+++ b/config/file_types.json
@@ -1,0 +1,7 @@
+{
+  "Docs": [".pdf", ".docx", ".xlsx", ".pptx", ".txt", ".csv", ".dotx", ".doc", ".ppt", ".potx", ".text"],
+  "Media": [".jpg", ".jpeg", ".png", ".gif", ".mp4", ".mov", ".mp3", ".wav", ".webm", ".svg", ".webp", ".ico", ".m4a"],
+  "Archives": [".zip", ".rar", ".tar", ".gz", ".7z"],
+  "Programs": [".exe", ".msi", ".dmg", ".pkg", ".sh", ".iso"],
+  "Development": [".py", ".js", ".html", ".css", ".cpp", ".java", ".sh", ".ipynb", ".json", ".md", ".m", ".drawio", ".ts", ".log", ".apk", ".db", ".sqlite", ".sql"]
+}

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ Also uses a system tray icon for user control.
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import logging
@@ -112,8 +113,9 @@ def update_menu(pytray_icon: Any) -> None:
     print("DEBUG: Menu updated.")
 
 
-# Each key is a category name and its value is a list of extensions that belong to that category.
-file_types = {
+# Default mapping between categories and file extensions.
+# The configuration file can override these values.
+DEFAULT_FILE_TYPES: dict[str, list[str]] = {
     "Docs": [
         ".pdf",
         ".docx",
@@ -166,6 +168,38 @@ file_types = {
     ],
 }
 
+
+def load_file_type_mappings(config_file_path: Path) -> dict[str, list[str]]:
+    """Load category-to-extension mappings from a JSON configuration file.
+
+    The configuration file should contain a JSON object where each key is a
+    category name and its corresponding value is a list of filename extensions.
+    If the file cannot be read or parsed, a copy of ``DEFAULT_FILE_TYPES`` is
+    returned instead.
+
+    Args:
+        config_file_path: Location of the JSON configuration file.
+
+    Returns:
+        A dictionary mapping category names to lists of file extensions.
+    """
+    try:
+        with config_file_path.open("r", encoding="utf-8") as config_file:
+            data = json.load(config_file)
+        if isinstance(data, dict) and all(isinstance(v, list) for v in data.values()):
+            return {str(k): [str(ext) for ext in v] for k, v in data.items()}
+    except Exception as error:  # pragma: no cover - logging handles visibility
+        logging.warning(
+            "Could not load configuration %s, using defaults: %s", config_file_path, error
+        )
+    return DEFAULT_FILE_TYPES.copy()
+
+
+CONFIG_FILE_PATH = Path(__file__).resolve().parent / "config" / "file_types.json"
+# Load the mappings at start-up. Users may edit the JSON file to customize
+# categories. Any errors fall back to the built-in defaults.
+file_types = load_file_type_mappings(CONFIG_FILE_PATH)
+
 # os.path.expanduser("~") so that the paths work across different operating systems.
 # On Windows, for example, os.path.expanduser("~") might be "C:\Users\name", while on macOS/Linux it would be "/Users/name" or "/home/name".
 folder_paths = {
@@ -177,6 +211,12 @@ folder_paths = {
     "Programs": os.path.join(os.path.expanduser("~"), "Desktop", "Programs"),
     "Development": os.path.join(os.path.expanduser("~"), "Desktop", "Development"),
 }
+
+# Ensure every category from the configuration has a destination folder.
+for category_name in file_types:
+    folder_paths.setdefault(
+        category_name, os.path.join(os.path.expanduser("~"), "Desktop", category_name)
+    )
 
 # Normalize the folder paths to ensure they are formatted correctly for the current operating system.
 path_to_folders = {key: os.path.normpath(value) for key, value in folder_paths.items()}


### PR DESCRIPTION
## Summary
- move file type categories into `config/file_types.json`
- load mappings from the JSON file at startup with a safe fallback
- document how to customize file type categories via configuration

## Testing
- `pytest`
- `ruff check main.py`


------
https://chatgpt.com/codex/tasks/task_e_68af31df2b788323b69f7c4ef8271d75