### PR TITLE
Enforce docstring conventions and add linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,9 @@ jobs:
 
       # 5) Lint (fast)
       - name: 🧹 Lint (ruff)
-        run: uv run ruff check .
+        run: |
+          uv run ruff check .
+          uv run ruff check --select D .
 
       # 6) Format check (non-destructive)
       - name: 🎨 Format check (black)

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ test:
 # -------- Lint (Ruff) --------
 lint:
 	uv run -m ruff check .
+	uv run -m ruff check --select D .
 
 # -------- Format (Black) --------
 format:

--- a/auto_gui.py
+++ b/auto_gui.py
@@ -1,9 +1,9 @@
-"""
-GUI utilities for the desktop automation script.
+"""GUI helpers for AutoSort.
 
-- Generating a custom folder icon with an arrow.
-- Displaying a pop-up prompt asking if a file is a meme.
+This module provides two utilities:
 
+* ``create_icon`` builds a folder icon with a U-turn arrow.
+* ``meme_yes_no`` displays a modal prompt asking if a file is a meme.
 """
 
 import math
@@ -12,19 +12,18 @@ from PIL import Image, ImageDraw
 
 
 def create_icon(width: int = 64, height: int = 64) -> Image.Image:
-    """
-    The icon consists of:
-      - A folder: drawn as a rectangle (folder body) and a polygon (folder tab).
-      - A U-turn arrow: drawn as an arc with a small arrow head at its end.
+    """Generate a folder icon with a U-turn arrow.
 
     Args:
-        width (int): The width of the icon image.
-        height (int): The height of the icon image.
+        width: Width of the icon image.
+        height: Height of the icon image.
 
     Returns:
-        PIL.Image: Generated icon image.
-    """
+        Image.Image: The generated icon.
 
+    Side Effects:
+        None.
+    """
     # Create a blank image with a white background.
     image = Image.new("RGB", (width, height), "white")
     draw = ImageDraw.Draw(image)
@@ -73,11 +72,13 @@ def create_icon(width: int = 64, height: int = 64) -> Image.Image:
 
 
 def meme_yes_no() -> bool:
-    """
-    Pop-up window asking "Meme?" with Yes and No buttons.
+    """Display a modal prompt asking whether a file is a meme.
 
     Returns:
-        bool: True if "Yes" is clicked, False if "No" is clicked.
+        bool: ``True`` if "Yes" is clicked and ``False`` otherwise.
+
+    Side Effects:
+        Creates and destroys a Tkinter window and blocks until the user responds.
     """
     is_meme = False  # Default value
 
@@ -110,12 +111,22 @@ def meme_yes_no() -> bool:
 
     # "Yes" button --> set is_meme to True and close the window.
     def on_yes() -> None:
+        """Mark selection as a meme and close the prompt.
+
+        Side Effects:
+            Updates ``is_meme`` and destroys the window.
+        """
         nonlocal is_meme
         is_meme = True
         root.destroy()
 
     # "No" button --> set is_meme to False and close the window.
     def on_no() -> None:
+        """Mark selection as not a meme and close the prompt.
+
+        Side Effects:
+            Updates ``is_meme`` and destroys the window.
+        """
         nonlocal is_meme
         is_meme = False
         root.destroy()

--- a/autofile/config.py
+++ b/autofile/config.py
@@ -74,7 +74,17 @@ DEFAULT_SKIP_EXTENSIONS: list[str] = [
 
 
 def _normalize_extensions(items: list[str]) -> list[str]:
-    """Normalize extensions by lowercasing and ensuring a leading dot."""
+    """Standardize a list of file extensions.
+
+    Args:
+        items: Raw extension strings that may lack a leading dot or use mixed case.
+
+    Returns:
+        list[str]: Normalized extensions in lower case starting with a dot.
+
+    Side Effects:
+        None.
+    """
     normalized: list[str] = []
     for raw in items:
         ext = str(raw).strip().lower()
@@ -87,7 +97,18 @@ def _normalize_extensions(items: list[str]) -> list[str]:
 
 
 def load_config(config_file_path: Path) -> tuple[dict[str, list[str]], set[str]]:
-    """Load sorting categories and skip-extensions from JSON config."""
+    """Load categories and skip extensions from a JSON configuration file.
+
+    Args:
+        config_file_path: Location of the configuration file.
+
+    Returns:
+        tuple[dict[str, list[str]], set[str]]: Mapping of categories to extensions and
+        a set of extensions that should be ignored.
+
+    Side Effects:
+        Reads the configuration from disk and logs warnings on failure.
+    """
     try:
         with config_file_path.open("r", encoding="utf-8") as f:
             data = json.load(f)

--- a/autofile/notifications.py
+++ b/autofile/notifications.py
@@ -25,7 +25,17 @@ except Exception:  # pragma: no cover
 
 
 def open_file_location(file_path: str) -> None:
-    """Open the system file explorer showing the given file."""
+    """Open the system file explorer showing the given file.
+
+    Args:
+        file_path: Path to highlight in the file explorer.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Launches the OS file explorer.
+    """
     normalized_path = os.path.normpath(os.path.abspath(file_path))
     try:
         if sys.platform.startswith("win"):
@@ -48,13 +58,32 @@ def show_notification(
     open_folder: Optional[str] = None,
     **toast_kwargs: Any,
 ) -> None:
-    """Show a Windows toast or print to console on other platforms."""
+    """Show a toast notification or log to the console.
+
+    Args:
+        message: Body of the notification.
+        title: Heading of the notification.
+        select_file: File path to reveal when the notification is clicked.
+        open_folder: Folder path to open when the notification is clicked.
+        **toast_kwargs: Additional keyword arguments forwarded to ``win_toast``.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Displays a notification or prints to stdout depending on the platform.
+    """
     if not sys.platform.startswith("win") or win_toast is None:
         logging.info("%s %s", title, message)
         print(title, message)
         return
 
     def callback(_: Any) -> None:
+        """Handle clicks on the notification.
+
+        Side Effects:
+            Opens the file explorer.
+        """
         if select_file:
             open_file_location(select_file)
         elif open_folder:
@@ -74,7 +103,18 @@ def show_notification(
 
 
 def progress_begin(initial_status: str, total: int) -> None:
-    """Start a progress notification."""
+    """Start a progress notification.
+
+    Args:
+        initial_status: Initial status message.
+        total: Total number of items to process.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Displays a progress toast or logs to stdout.
+    """
     if not sys.platform.startswith("win") or win_notify is None:
         logging.info("[Progress] %s 0/%d", initial_status, total)
         print(f"[Progress] {initial_status} 0/{total}")
@@ -98,7 +138,19 @@ def progress_begin(initial_status: str, total: int) -> None:
 
 
 def progress_update(done: int, total: int, status: str | None = None) -> None:
-    """Update the active progress notification."""
+    """Update the active progress notification.
+
+    Args:
+        done: Number of completed items.
+        total: Total number of items.
+        status: Optional status message.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Updates the displayed toast or console output.
+    """
     ratio = 0.0 if total <= 0 else max(0.0, min(1.0, done / total))
     if not sys.platform.startswith("win") or win_update_progress is None:
         msg = f"[Progress] {status or 'Working...'} {done}/{total} ({int(ratio*100)}%)"
@@ -125,7 +177,17 @@ def progress_update(done: int, total: int, status: str | None = None) -> None:
 
 
 def progress_complete(message: str = "Completed!") -> None:
-    """Mark the progress toast as completed."""
+    """Mark the progress notification as completed.
+
+    Args:
+        message: Final status text.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Updates the toast notification or prints to stdout.
+    """
     if not sys.platform.startswith("win") or win_update_progress is None:
         logging.info("[Progress] %s", message)
         print(f"[Progress] {message}")

--- a/autofile/sorter.py
+++ b/autofile/sorter.py
@@ -27,7 +27,18 @@ meme_enabled: bool = True
 
 
 def check_name(dest_folder: str, entry_name: str) -> str:
-    """Return a non-conflicting destination path for a file."""
+    """Return a destination path that avoids name collisions.
+
+    Args:
+        dest_folder: Folder where the file will be placed.
+        entry_name: Original file name.
+
+    Returns:
+        str: A destination path that does not overwrite existing files.
+
+    Side Effects:
+        None.
+    """
     file_name, extension = os.path.splitext(entry_name)
     destination_path_name = os.path.join(dest_folder, entry_name)
     if os.path.exists(destination_path_name):
@@ -43,7 +54,17 @@ def check_name(dest_folder: str, entry_name: str) -> str:
 
 
 def should_skip_by_extension(filename: str) -> bool:
-    """Return True if the file's extension is configured to be skipped."""
+    """Determine whether a file's extension is configured to be skipped.
+
+    Args:
+        filename: Name of the file to evaluate.
+
+    Returns:
+        bool: ``True`` if the extension is in ``SKIP_EXTENSIONS``.
+
+    Side Effects:
+        None.
+    """
     _, ext = os.path.splitext(filename.lower())
     return ext in SKIP_EXTENSIONS
 
@@ -51,7 +72,19 @@ def should_skip_by_extension(filename: str) -> bool:
 def is_file_fully_downloaded(
     file_path: str, wait_time: int = 1, check_interval: int = 1
 ) -> bool:
-    """Wait until the file size stops changing."""
+    """Wait until a file's size stabilizes.
+
+    Args:
+        file_path: Path to the file being monitored.
+        wait_time: Seconds that the size must remain constant.
+        check_interval: Delay between size checks in seconds.
+
+    Returns:
+        bool: ``True`` when the file size stops changing.
+
+    Side Effects:
+        Reads the file size repeatedly and sleeps between checks.
+    """
     prev_size = -1
     stable_count = 0
     while stable_count < wait_time:
@@ -66,7 +99,18 @@ def is_file_fully_downloaded(
 
 
 def resolve_destination(path: str, ask_meme: bool = False) -> Optional[str]:
-    """Compute the destination folder for a file based on extension."""
+    """Determine the destination folder for a file based on its extension.
+
+    Args:
+        path: File path to classify.
+        ask_meme: Whether to prompt the user when classifying media files.
+
+    Returns:
+        Optional[str]: Destination folder or ``None`` if no match is found.
+
+    Side Effects:
+        May invoke a GUI prompt when ``ask_meme`` is ``True``.
+    """
     entry_name = os.path.basename(path)
     if should_skip_by_extension(entry_name) or not os.path.isfile(path):
         return None
@@ -86,7 +130,19 @@ def resolve_destination(path: str, ask_meme: bool = False) -> Optional[str]:
 def sort_file(
     path: str, notify: bool = True, planned_dest: Optional[str] = None
 ) -> Optional[str]:
-    """Move a single file to its destination folder."""
+    """Move a single file to its destination folder.
+
+    Args:
+        path: Path of the file to move.
+        notify: Whether to display a notification after moving.
+        planned_dest: Destination folder override.
+
+    Returns:
+        Optional[str]: Final destination path if the file was moved.
+
+    Side Effects:
+        Moves files on disk and may display a notification or prompt.
+    """
     entry_name = os.path.basename(path)
     if should_skip_by_extension(entry_name) or not os.path.isfile(path):
         return None
@@ -114,7 +170,15 @@ def sort_file(
 
 
 def sort_files() -> None:
-    """Batch-scan the Downloads folder and move eligible files."""
+    """Scan the Downloads folder and move eligible files.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Moves files, displays notifications and progress toasts, and creates
+        destination folders as needed.
+    """
     moved_files: list[str] = []
     try:
         if not os.path.exists(DOWNLOADS_FOLDER_PATH):

--- a/autofile/tray.py
+++ b/autofile/tray.py
@@ -23,7 +23,17 @@ pytray_icon: Optional[Any] = None
 
 
 def set_windows_app_id(app_id: str = APP_ID) -> None:
-    """Set Windows App User Model ID for toast notifications."""
+    """Configure the App User Model ID for Windows notifications.
+
+    Args:
+        app_id: Identifier used by the notification system.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Registers the process with Windows; no effect on other platforms.
+    """
     if not sys.platform.startswith("win"):
         return
     try:  # pragma: no cover
@@ -35,24 +45,64 @@ def set_windows_app_id(app_id: str = APP_ID) -> None:
 
 
 def start_action(icon: Any) -> None:
-    """Callback for the 'Start' menu item."""
+    """Start watching for file changes and refresh the menu.
+
+    Args:
+        icon: Pystray icon instance.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Begins filesystem monitoring and updates the tray menu.
+    """
     start_watching()
     update_menu(icon)
 
 
 def stop_action(icon: Any) -> None:
-    """Callback for the 'Stop' menu item."""
+    """Stop watching for file changes and refresh the menu.
+
+    Args:
+        icon: Pystray icon instance.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Stops filesystem monitoring and updates the tray menu.
+    """
     stop_watching()
     update_menu(icon)
 
 
 def quit_action(icon: Any) -> None:
-    """Quit the application."""
+    """Exit the tray application.
+
+    Args:
+        icon: Pystray icon instance.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Stops the icon's event loop.
+    """
     icon.stop()
 
 
 def update_menu(icon: Any) -> None:
-    """Rebuild the tray menu based on current state."""
+    """Rebuild the tray menu based on the observer state.
+
+    Args:
+        icon: Pystray icon instance.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Mutates the menu of the provided icon.
+    """
     menu = pystray.Menu(
         item(
             "Start" + (" (active)" if observer is not None else ""),
@@ -70,9 +120,20 @@ def update_menu(icon: Any) -> None:
 
 
 class MyEventHandler(FileSystemEventHandler):
-    """Custom event handler that monitors changes in the Downloads folder."""
+    """Monitor changes in the Downloads folder and trigger sorting."""
 
     def on_modified(self, event: FileSystemEvent) -> None:
+        """Handle file modification events.
+
+        Args:
+            event: Watchdog event describing the change.
+
+        Returns:
+            None.
+
+        Side Effects:
+            Sorts the file if eligible.
+        """
         time.sleep(1)
         src = event.src_path if isinstance(event.src_path, str) else str(event.src_path)
         if event.is_directory:
@@ -84,7 +145,14 @@ class MyEventHandler(FileSystemEventHandler):
 
 
 def start_watching() -> None:
-    """Start the watchdog observer to monitor the Downloads folder."""
+    """Begin monitoring the Downloads folder.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Starts a watchdog observer and may immediately sort existing files.
+    """
     global observer
     if observer is None:
         event_handler = MyEventHandler()
@@ -95,7 +163,14 @@ def start_watching() -> None:
 
 
 def stop_watching() -> None:
-    """Stop the watchdog observer if it's running."""
+    """Stop the active watchdog observer.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Terminates the observer thread.
+    """
     global observer
     if observer is not None:
         observer.stop()
@@ -104,7 +179,15 @@ def stop_watching() -> None:
 
 
 def main() -> None:
-    """Main entry point for the AutoSort tray application."""
+    """Launch the system tray application.
+
+    Returns:
+        None.
+
+    Side Effects:
+        Creates a tray icon, starts a GUI event loop, and begins monitoring the
+        Downloads folder.
+    """
     global pytray_icon
     try:
         set_windows_app_id(APP_ID)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,6 @@ module = [
   "plyer.*",
 ]
 ignore_missing_imports = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,3 +1,6 @@
+"""Placeholder tests for AutoSort."""
+
+
 def test_placeholder() -> None:
     """Trivial test to ensure the test suite runs."""
     assert True


### PR DESCRIPTION
## Summary
- standardize docstrings across project using Google style
- add docstring lint checks with Ruff in Makefile and CI
- configure Ruff to enforce Google docstring convention

## Testing
- `make format`
- `make lint`
- `make format-check`
- `make type-check`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68afe61484c08323ba6f324340c95f44